### PR TITLE
Documentation cleanup and a note around Ubuntu 20.04 TLS support

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,7 @@ DICOM Reception over TLS Connection
 
 .. important:: Due to an incompatibility in DICOM toolkit v3.6.4 and OpenSSL v1.1.1, the dcmtk and openssl versions supported by Ubuntu 20.04, only Ubuntu 22.04 mercure installs support TLS reception.
 
-The following environment variables must be defined to run mercure in DICOM TLS receiver mode. This can be done, for example, by adding the to the /etc/environment file. First, set `MERCURE_TLS_ENABLED` to `1`. Next, specify the paths to your server TLS key, certificate, and CA certificate, as shown in the below example configuration.
+The following environment variables must be defined to run mercure in DICOM TLS receiver mode. This can be done, for example, by adding the values to the /etc/environment file. First, set `MERCURE_TLS_ENABLED` to `1`. Next, specify the paths to your server TLS key, certificate, and CA certificate, as shown in the below sample configuration.
 
 ========================================= =====================================
 Environment Variable                      Example Value
@@ -80,7 +80,7 @@ MERCURE_TLS_CERT                          /opt/mercure/tls/certificate.pem
 MERCURE_TLS_CA_CERT                       /opt/mercure/tls/CA_certificate.pem
 ========================================= =====================================
 
-.. note:: The following example shows how to create your own Certificate Authority (CA) to self-sign your own certificates. In production, you will likely use your organization's certificate authority to sign the TLS receiver certificate, or create your CA as an intermediate CA from your organizational CA.
+.. note:: The following example shows how to create your own Certificate Authority (CA) to self-sign your own certificates. In production, you will likely use your organization's certificate authority to sign the TLS receiver certificate, or create an intermediate CA from your organizational CA to sign CSR when generating certificates.
 
 Here are some example steps to create a self-signed certificate authority and TLS key/certificate that can be utilized for use mercure in DICOM TLS receiver mode.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -67,20 +67,22 @@ DICOM Reception over TLS Connection
 
 .. important:: Support for the DICOM TLS receiver mode is still experimental and should be used with care.
 
-The following environment variables must be defined to run mercure in DICOM TLS receiver mode. First, set `MERCURE_TLS_ENABLED` to `1`. Next, specify the paths to your server TLS key, certificate, and CA certificate, as shown in the below example configuration.
+.. important:: Due to an incompatibility in DICOM toolkit v3.6.4 and OpenSSL v1.1.1, the dcmtk and openssl versions supported by Ubuntu 20.04, only Ubuntu 22.04 mercure installs support TLS reception.
+
+The following environment variables must be defined to run mercure in DICOM TLS receiver mode. This can be done, for example, by adding the to the /etc/environment file. First, set `MERCURE_TLS_ENABLED` to `1`. Next, specify the paths to your server TLS key, certificate, and CA certificate, as shown in the below example configuration.
 
 ========================================= =====================================
 Environment Variable                      Example Value
 ========================================= =====================================
 MERCURE_TLS_ENABLED                       1
-MERCURE_TLS_KEY                           /opt/mercure/certs/private_key.pem
-MERCURE_TLS_CERT                          /opt/mercure/certs/certificate.pem
-MERCURE_TLS_CA_CERT                       /opt/mercure/certs/CA_certificate.pem
+MERCURE_TLS_KEY                           /opt/mercure/tls/private_key.pem
+MERCURE_TLS_CERT                          /opt/mercure/tls/certificate.pem
+MERCURE_TLS_CA_CERT                       /opt/mercure/tls/CA_certificate.pem
 ========================================= =====================================
 
-.. important:: The following example shows how to create your own Certificate Authority (CA) to self-sign your own certificates. In production, it makes sense to use your organization's certificate authority to sign your TLS receiver certificates instead, or create your CA as an intermediate CA from your organizational CA.
+.. note:: The following example shows how to create your own Certificate Authority (CA) to self-sign your own certificates. In production, you will likely use your organization's certificate authority to sign the TLS receiver certificate, or create your CA as an intermediate CA from your organizational CA.
 
-Here are the steps required to create a self-signed certificate authority and TLS key/certificate keypair that can be used to use mercure in DICOM TLS receiver mode.
+Here are some example steps to create a self-signed certificate authority and TLS key/certificate that can be utilized for use mercure in DICOM TLS receiver mode.
 
 * Step 1: Generate the CA key: `openssl genrsa -out CA_key.pem 4096`
 * Step 2: Create the CA certificate: `openssl req -new -x509 -days 3650 -key CA_key.pem -out CA_certificate.pem`

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -90,6 +90,8 @@ For DICOM TLS targets, enter the TLS client key path, TLS client certificate pat
 
 .. important:: Support for DICOM TLS transfers is still experimental and should be used with care.
 
+.. important:: Due to an incompatibility in DICOM toolkit v3.6.4 and OpenSSL v1.1.1, the dcmtk and openssl versions supported by Ubuntu 20.04, only Ubuntu 22.04 mercure installs support DICOM+TLS targets.
+
 On the "Information" tab, you can add information for documentation purpose, including a contact e-mail address (so that it can be looked up who should be contacted if problems with the target occur) and a description of the target.
 
 


### PR DESCRIPTION
- [x] Add important note that Ubuntu 20.04 uses dcmtk v3.6.4 which is compatible with openssl  v1.1.0, but v1.1.1 is installed on Ubuntu 20.04 which breaks DICOM+TLS. Ubuntu 22.04 works just fine.
- [x] General documentation fixes, trying to clean up the grammar a bit.
- [x] Refer to `/opt/mercure/tls/*` instead of `/opt/mercure/certs/*` since keys are stored there in our example.
- [x] Mentioned the `/etc/environment` variable that can be used to define the TLS environment variables. I'm not sure if you want to keep this one as there are lots of ways to specify environment variables.