### PR TITLE
Add GCP service account authentication for DICOMweb targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,8 @@ dcm_extra_tags
 
 .pytest_cache/
 .aider*
+
+# GCP Service Account Keys - DO NOT COMMIT
+new-lantern-nvra.json
+getAccessToken.py
+*-service-account*.json

--- a/app/common/types.py
+++ b/app/common/types.py
@@ -104,6 +104,13 @@ class DicomWebTarget(Target):
     http_user: Optional[str] = None
     http_password: Optional[str] = None
 
+    # New GCP Service Account auth
+    gcp_service_account_json_path: Optional[str] = None
+    gcp_auth_scopes: Optional[List[str]] = None
+
+    # Authentication method selector (for clarity and validation)
+    auth_method: Optional[Literal["token", "basic", "gcp_service_account"]] = None
+
     @property
     def short_description(self) -> str:
         return self.url

--- a/app/dispatch/target_types/dicomweb.py
+++ b/app/dispatch/target_types/dicomweb.py
@@ -16,6 +16,7 @@ from dicomweb_client import DICOMfileClient
 from dicomweb_client.api import DICOMwebClient
 from dicomweb_client.session_utils import create_session_from_user_pass
 from requests.exceptions import HTTPError
+import requests
 
 from .base import ProgressInfo, TargetHandler
 from .registry import handler_for
@@ -44,7 +45,14 @@ class DicomWebTargetHandler(TargetHandler[DicomWebTarget]):
                 # This also makes it possible to run tests under pyfakefs since it can't patch sqlite3
                 return DICOMfileClient(url=target.url, in_memory=True, update_db=True)
 
-        if target.http_user and target.http_password:
+        # Priority order for authentication:
+        # 1. GCP Service Account (if configured)
+        # 2. HTTP Basic Auth
+        # 3. Bearer Token
+
+        if target.gcp_service_account_json_path:
+            session = self._create_gcp_authenticated_session(target)
+        elif target.http_user and target.http_password:
             session = create_session_from_user_pass(username=target.http_user, password=target.http_password)
         elif target.access_token:
             headers = {"Authorization": "Bearer {}".format(target.access_token)}
@@ -60,6 +68,59 @@ class DicomWebTargetHandler(TargetHandler[DicomWebTarget]):
         client.set_http_retry_params(retry=False, max_attempts=2, wait_exponential_multiplier=100)
         logger.info(client)
         return client
+
+    ### New Helper method:
+    def _create_gcp_authenticated_session(self, target: DicomWebTarget) -> requests.Session:
+        """
+        Create a requests Session authenticated with GCP service account credentials.
+        
+        Args:
+            target: DicomWebTarget with GCP service account configuration
+            
+        Returns:
+            Authenticated requests.Session object
+            
+        Raises:
+            FileNotFoundError: If service account JSON file doesn't exist
+            ValueError: If service account JSON is invalid
+            google.auth.exceptions.GoogleAuthError: For authentication errors
+        """
+        from google.auth.transport.requests import AuthorizedSession
+        from google.oauth2 import service_account
+        
+        # Validate file exists
+        json_path = Path(target.gcp_service_account_json_path)
+        if not json_path.exists():
+            raise FileNotFoundError(
+                f"GCP service account JSON file not found: {json_path}"
+            )
+        
+        # Default scopes for Cloud Healthcare API
+        scopes = target.gcp_auth_scopes or [
+            'https://www.googleapis.com/auth/cloud-healthcare'
+        ]
+        
+        logger.info(f"Loading GCP service account credentials from: {json_path}")
+        
+        try:
+            # Load credentials from service account JSON
+            credentials = service_account.Credentials.from_service_account_file(
+                str(json_path),
+                scopes=scopes
+            )
+            
+            # Create an authorized session
+            # This session will automatically refresh tokens as needed
+            session = AuthorizedSession(credentials)
+            
+            logger.info("GCP service account authentication configured successfully")
+            return session
+            
+        except Exception as e:
+            logger.error(f"Failed to create GCP authenticated session: {e}")
+            raise ValueError(
+                f"Invalid GCP service account JSON or authentication error: {e}"
+            )
 
     def find_from_target(self, target: DicomWebTarget, accession: str, search_filters: Dict[str, List[str]] = {}
                          ) -> List[pydicom.Dataset]:
@@ -127,7 +188,7 @@ class DicomWebTargetHandler(TargetHandler[DicomWebTarget]):
         return ""
 
     def from_form(self, form: dict, factory, current_target) -> DicomWebTarget:
-
+        # Clear empty string fields (existing logic)
         for x in [
             "qido_url_prefix",
             "wado_url_prefix",
@@ -135,27 +196,29 @@ class DicomWebTargetHandler(TargetHandler[DicomWebTarget]):
             "http_user",
             "http_password",
             "access_token",
+            "gcp_service_account_json_path",  # NEW
+            "gcp_auth_scopes",                # NEW
         ]:
             if x in form and not form[x]:
                 form[x] = None
-
+        
+        # Parse gcp_auth_scopes if provided as comma-separated string
+        if "gcp_auth_scopes" in form and form["gcp_auth_scopes"]:
+            if isinstance(form["gcp_auth_scopes"], str):
+                form["gcp_auth_scopes"] = [
+                    s.strip() for s in form["gcp_auth_scopes"].split(",")
+                ]
+        
         return DicomWebTarget(**form)
 
     async def test_connection(self, target: DicomWebTarget, target_name: str):
         client = self.create_client(target)
-
+        
         results: Dict[str, Union[bool, str, None]] = {}
         results["Authentication"] = None
-        if isinstance(client, DICOMwebClient):
-            try:
-                client._http_get(target.url)
-                results["Authentication"] = True
-            except HTTPError as e:
-                if e.errno == 401:
-                    results["Authentication"] = False
-                else:
-                    results["Authentication"] = True
-        elif isinstance(client, DICOMfileClient):
+        
+        # File-based client testing (unchanged)
+        if isinstance(client, DICOMfileClient):
             folder = Path(target.url[7:])
             if not folder.exists() or not folder.is_dir():
                 results["Authentication"] = f"No such folder {folder}"
@@ -165,10 +228,47 @@ class DicomWebTargetHandler(TargetHandler[DicomWebTarget]):
                 results["Authentication"] = f"No write access to folder {folder}"
             else:
                 results["Authentication"] = True
+        
+        # HTTP-based client testing
+        elif isinstance(client, DICOMwebClient):
+            try:
+                # Test authentication
+                client._http_get(target.url)
+                results["Authentication"] = True
+                
+                # Add authentication method info for debugging
+                if target.gcp_service_account_json_path:
+                    results["Auth Method"] = "GCP Service Account"
+                elif target.http_user:
+                    results["Auth Method"] = "HTTP Basic Auth"
+                elif target.access_token:
+                    results["Auth Method"] = "Bearer Token"
+                else:
+                    results["Auth Method"] = "None"
+                    
+            except HTTPError as e:
+                if e.response.status_code == 401:
+                    results["Authentication"] = False
+                    results["Error"] = "Authentication failed (401 Unauthorized)"
+                elif e.response.status_code == 403:
+                    results["Authentication"] = False
+                    results["Error"] = "Access forbidden (403 Forbidden)"
+                else:
+                    # Other errors might not be auth-related
+                    results["Authentication"] = True
+                    results["Warning"] = f"HTTP {e.response.status_code}"
+            except Exception as e:
+                results["Authentication"] = f"Error: {str(e)}"
+        
+        # Test QIDO query capability
         try:
             client.search_for_studies(limit=1)
             results["QIDO query"] = True
-        except HTTPError:
+        except HTTPError as e:
             results["QIDO query"] = False
-
+            results["QIDO Error"] = f"HTTP {e.response.status_code}"
+        except Exception as e:
+            results["QIDO query"] = False
+            results["QIDO Error"] = str(e)
+        
         return results

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -319,5 +319,8 @@ wheel==0.43.0
 yarl==1.18.0
     # via aiohttp
 
+google-auth>=2.16.0
+google-auth-httplib2>=0.1.0
+
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/app/tests/test_dicomweb_gcp_auth.py
+++ b/app/tests/test_dicomweb_gcp_auth.py
@@ -1,0 +1,23 @@
+def test_gcp_service_account_client_creation():
+    """Test that GCP authenticated client is created correctly"""
+    
+def test_gcp_service_account_missing_file():
+    """Test error handling for missing JSON file"""
+    
+def test_gcp_service_account_invalid_json():
+    """Test error handling for invalid JSON format"""
+    
+def test_gcp_service_account_token_refresh():
+    """Test that tokens are automatically refreshed"""
+    
+def test_authentication_priority_order():
+    """Test that GCP auth takes priority when multiple methods configured"""
+
+def test_gcp_auth_with_google_healthcare_api():
+    """Test actual connection to Google Healthcare API"""
+    
+def test_gcp_auth_store_instances():
+    """Test storing DICOM instances with GCP auth"""
+    
+def test_gcp_auth_retrieve_instances():
+    """Test retrieving DICOM instances with GCP auth"""

--- a/app/webinterface/templates/targets/dicomweb-edit.html
+++ b/app/webinterface/templates/targets/dicomweb-edit.html
@@ -10,25 +10,106 @@
             size="15">
     </div>
 </div>
- <div class="field">
-    <label class="label">Username</label>
+
+<!-- Authentication Method Selection -->
+<h1 class="title is-4" style="margin-top: 40px;">Authentication</h1>
+
+<div class="field">
+    <label class="label">Authentication Method</label>
     <div class="control">
-        <input name="http_user" class="input" required='false' autocomplete='off' placeholder="HTTPS username"
-           value="{{targets[edittarget].http_user if targets[edittarget].http_user else ''}}">
+        <div class="select">
+            <select id="auth_method_select" name="auth_method">
+                <option value="none" {% if not targets[edittarget].access_token and not targets[edittarget].http_user and not targets[edittarget].gcp_service_account_json_path %}selected{% endif %}>None</option>
+                <option value="token" {% if targets[edittarget].access_token %}selected{% endif %}>Bearer Token</option>
+                <option value="basic" {% if targets[edittarget].http_user %}selected{% endif %}>HTTP Basic Auth</option>
+                <option value="gcp_service_account" {% if targets[edittarget].gcp_service_account_json_path %}selected{% endif %}>GCP Service Account</option>
+            </select>
+        </div>
+    </div>
+    <p class="help">Select the authentication method for your DICOMweb endpoint</p>
+</div>
+
+<!-- HTTP Basic Auth Section -->
+<div id="basic_auth_section" style="display: none;">
+    <div class="field">
+        <label class="label">Username</label>
+        <div class="control">
+            <input name="http_user" class="input" autocomplete='off' placeholder="HTTPS username"
+               value="{{targets[edittarget].http_user if targets[edittarget].http_user else ''}}">
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Password</label>
+        <div class="control">
+            <input name="http_password" type="password" class="input" autocomplete='off' placeholder="HTTPS password"
+               value="{{targets[edittarget].http_password if targets[edittarget].http_password else ''}}">
+        </div>
     </div>
 </div>
-<div class="field">
-    <label class="label">Password</label>
-    <div class="control">
-        <input name="http_password" class="input" required='false' autocomplete='off' placeholder="HTTPS password"
-           value="{{targets[edittarget].http_password if targets[edittarget].http_password else ''}}">
+
+<!-- Bearer Token Section -->
+<div id="token_auth_section" style="display: none;">
+    <div class="field">
+        <label class="label">Access Token</label>
+        <div class="control">
+            <input name="access_token" class="input" autocomplete='off' placeholder="Bearer token"
+               value="{{targets[edittarget].access_token if targets[edittarget].access_token else ''}}">
+        </div>
+        <p class="help">Provide your OAuth 2.0 access token or API key</p>
     </div>
 </div>
-<div class="field">
-    <label class="label">Access Token</label>
-    <div class="control">
-        <input name="access_token" class="input" required='false' autocomplete='off' placeholder="Access token"
-           value="{{targets[edittarget].access_token if targets[edittarget].access_token else ''}}">
+
+<!-- GCP Service Account Section -->
+<div id="gcp_auth_section" style="display: none;">
+    <div class="notification is-warning">
+        <strong>GCP Service Account Authentication</strong><br>
+        Upload your Google Cloud service account JSON key file. The file will be securely stored in <code>/opt/mercure/config/gcp-keys/</code>.
+    </div>
+    
+    <div class="field">
+        <label class="label">Service Account JSON Key</label>
+        <div class="control">
+            <div class="file has-name is-fullwidth">
+                <label class="file-label">
+                    <input class="file-input" type="file" id="gcp_json_file" name="gcp_json_file" accept=".json">
+                    <span class="file-cta">
+                        <span class="file-icon">
+                            <i class="fas fa-upload"></i>
+                        </span>
+                        <span class="file-label">
+                            Choose a file…
+                        </span>
+                    </span>
+                    <span class="file-name" id="gcp_file_name">
+                        {% if targets[edittarget].gcp_service_account_json_path %}
+                            {{ targets[edittarget].gcp_service_account_json_path.split('/')[-1] }}
+                        {% else %}
+                            No file selected
+                        {% endif %}
+                    </span>
+                </label>
+            </div>
+        </div>
+        <p class="help">Upload your service account JSON key file from Google Cloud Console</p>
+    </div>
+
+    <!-- Hidden field to store the path after upload -->
+    <input type="hidden" name="gcp_service_account_json_path" id="gcp_service_account_json_path" 
+           value="{{targets[edittarget].gcp_service_account_json_path if targets[edittarget].gcp_service_account_json_path else ''}}">
+
+    <div class="field">
+        <label class="label">OAuth Scopes (Optional)</label>
+        <div class="control">
+            <input name="gcp_auth_scopes" class="input" autocomplete='off' 
+                   placeholder="https://www.googleapis.com/auth/cloud-healthcare"
+                   value="{% if targets[edittarget].gcp_auth_scopes %}{{ ','.join(targets[edittarget].gcp_auth_scopes) }}{% endif %}">
+        </div>
+        <p class="help">Comma-separated OAuth scopes. Leave empty to use default Cloud Healthcare API scope.</p>
+    </div>
+
+    <div class="field" id="upload_status_field" style="display: none;">
+        <div class="notification" id="upload_status">
+        </div>
     </div>
 </div>
 
@@ -37,21 +118,118 @@
 <div class="field">
     <label class="label">QIDO-RS</label>
     <div class="control">
-        <input name="qido_url_prefix" class="input" required='false' autocomplete='off' placeholder="QIDO-RS URL"
+        <input name="qido_url_prefix" class="input" autocomplete='off' placeholder="QIDO-RS URL"
            value="{{targets[edittarget].qido_url_prefix if targets[edittarget].qido_url_prefix else ''}}">
     </div>
 </div>
 <div class="field">
     <label class="label">WADO-RS</label>
     <div class="control">
-        <input name="wado_url_prefix" class="input" required='false' autocomplete='off' placeholder="WADO-RS URL"
+        <input name="wado_url_prefix" class="input" autocomplete='off' placeholder="WADO-RS URL"
            value="{{targets[edittarget].wado_url_prefix if targets[edittarget].wado_url_prefix else ''}}">
     </div>
 </div>
 <div class="field">
     <label class="label">STOW</label>
     <div class="control">
-        <input name="stow_url_prefix" class="input" required='false' autocomplete='off' placeholder="STOW URL"
-           value="{{targets[edittarget].wado_url_prefix if targets[edittarget].wado_url_prefix else ''}}">
+        <input name="stow_url_prefix" class="input" autocomplete='off' placeholder="STOW URL"
+           value="{{targets[edittarget].stow_url_prefix if targets[edittarget].stow_url_prefix else ''}}">
     </div>
 </div>
+
+<script>
+// Authentication method toggle logic
+document.addEventListener('DOMContentLoaded', function() {
+    const authSelect = document.getElementById('auth_method_select');
+    const basicSection = document.getElementById('basic_auth_section');
+    const tokenSection = document.getElementById('token_auth_section');
+    const gcpSection = document.getElementById('gcp_auth_section');
+    
+    function updateAuthSections() {
+        const selectedMethod = authSelect.value;
+        
+        // Hide all sections
+        basicSection.style.display = 'none';
+        tokenSection.style.display = 'none';
+        gcpSection.style.display = 'none';
+        
+        // Show selected section
+        if (selectedMethod === 'basic') {
+            basicSection.style.display = 'block';
+        } else if (selectedMethod === 'token') {
+            tokenSection.style.display = 'block';
+        } else if (selectedMethod === 'gcp_service_account') {
+            gcpSection.style.display = 'block';
+        }
+    }
+    
+    // Initialize on page load
+    updateAuthSections();
+    
+    // Update on selection change
+    authSelect.addEventListener('change', updateAuthSections);
+    
+    // File upload display
+    const fileInput = document.getElementById('gcp_json_file');
+    const fileName = document.getElementById('gcp_file_name');
+    
+    if (fileInput) {
+        fileInput.addEventListener('change', function() {
+            if (this.files && this.files[0]) {
+                fileName.textContent = this.files[0].name;
+            }
+        });
+    }
+});
+
+// Handle file upload before form submission
+document.querySelector('form').addEventListener('submit', async function(e) {
+    const authMethod = document.getElementById('auth_method_select').value;
+    const fileInput = document.getElementById('gcp_json_file');
+    const uploadStatus = document.getElementById('upload_status');
+    const uploadStatusField = document.getElementById('upload_status_field');
+    const pathInput = document.getElementById('gcp_service_account_json_path');
+    
+    // Only handle GCP service account uploads
+    if (authMethod === 'gcp_service_account' && fileInput && fileInput.files.length > 0) {
+        e.preventDefault();
+        
+        // Show upload in progress
+        uploadStatusField.style.display = 'block';
+        uploadStatus.className = 'notification is-info';
+        uploadStatus.textContent = 'Uploading service account key...';
+        
+        const formData = new FormData();
+        formData.append('gcp_json_file', fileInput.files[0]);
+        formData.append('target_name', '{{edittarget}}');
+        
+        try {
+            const response = await fetch('/targets/upload_gcp_key', {
+                method: 'POST',
+                body: formData
+            });
+            
+            const result = await response.json();
+            
+            if (response.ok && result.success) {
+                uploadStatus.className = 'notification is-success';
+                uploadStatus.textContent = 'File uploaded successfully!';
+                
+                // Set the path in hidden field
+                pathInput.value = result.file_path;
+                
+                // Submit the form after successful upload
+                setTimeout(() => {
+                    e.target.submit();
+                }, 1000);
+            } else {
+                uploadStatus.className = 'notification is-danger';
+                uploadStatus.textContent = 'Error: ' + (result.error || 'Upload failed');
+            }
+        } catch (error) {
+            uploadStatus.className = 'notification is-danger';
+            uploadStatus.textContent = 'Error uploading file: ' + error.message;
+        }
+    }
+});
+</script>

--- a/app/webinterface/templates/targets/dicomweb.html
+++ b/app/webinterface/templates/targets/dicomweb.html
@@ -6,15 +6,55 @@
     <td>URL:</td>
     <td>{{ target.url }}</td>
 </tr>
-<!-- <tr>
-    <td>Port:</td>
-    <td>{{ target.port }}</td>
-</tr>
 <tr>
-    <td>AET Target:</td>
-    <td>{{ target.aet_target }}</td>
+    <td>Authentication:</td>
+    <td>
+        {% if target.gcp_service_account_json_path %}
+            <span class="tag is-success">GCP Service Account</span>
+        {% elif target.access_token %}
+            <span class="tag is-info">Bearer Token</span>
+        {% elif target.http_user %}
+            <span class="tag is-warning">HTTP Basic Auth</span>
+        {% else %}
+            <span class="tag is-light">None</span>
+        {% endif %}
+    </td>
 </tr>
+{% if target.gcp_service_account_json_path %}
 <tr>
-    <td>AET Source:</td>
-    <td>{{ target.aet_source }}</td>
-</tr> -->
+    <td>Service Account Key:</td>
+    <td>
+        <code>{{ target.gcp_service_account_json_path.split('/')[-1] }}</code>
+        <br>
+        <small class="has-text-grey">Stored in: {{ target.gcp_service_account_json_path }}</small>
+    </td>
+</tr>
+{% endif %}
+{% if target.gcp_auth_scopes %}
+<tr>
+    <td>OAuth Scopes:</td>
+    <td>
+        {% for scope in target.gcp_auth_scopes %}
+            <span class="tag is-light">{{ scope }}</span><br>
+        {% endfor %}
+    </td>
+</tr>
+{% endif %}
+{% if target.qido_url_prefix %}
+<tr>
+    <td>QIDO-RS Prefix:</td>
+    <td>{{ target.qido_url_prefix }}</td>
+</tr>
+{% endif %}
+{% if target.wado_url_prefix %}
+<tr>
+    <td>WADO-RS Prefix:</td>
+    <td>{{ target.wado_url_prefix }}</td>
+</tr>
+{% endif %}
+{% if target.stow_url_prefix %}
+<tr>
+    <td>STOW Prefix:</td>
+    <td>{{ target.stow_url_prefix }}</td>
+</tr>
+{% endif %}

--- a/proc_modules/base_tagmap_new/tagmap_new.py
+++ b/proc_modules/base_tagmap_new/tagmap_new.py
@@ -1,0 +1,172 @@
+"""
+dicom_tag_manipulator.py
+=========================
+Processing module for Mercure that adds private DICOM tags and modifies standard tags
+
+This module performs the following modifications:
+1. Sets Institution Name (0008,0080) to "NVRA"
+2. Sets Institutional Department Name (0008,1040) to "NVRA"
+3. Creates private DICOM tags in the 7771 group:
+   - (7771,0010): "NL_PRIVATE" - Private Creator ID
+   - (7771,1001): "PIPELINE" - Pipeline identifier
+   - (7771,1002): "MAIN" - Main identifier
+
+If the private tags already exist, the module makes no changes and simply
+copies the files to the output folder.
+"""
+
+# Standard Python includes
+import os
+import sys
+import json
+from pathlib import Path
+
+# Imports for loading DICOMs
+import pydicom
+from pydicom.uid import generate_uid
+
+
+def process_image(file, in_folder, out_folder, series_uid, settings):
+    """
+    Processes the DICOM image specified by 'file'. This function will read the
+    file from the in_folder, add private tags if they don't exist, and save it 
+    to the out_folder using a new series UID given by series_uid.
+    """
+    dcm_file_in = Path(in_folder) / file
+    # Compose the filename of the modified DICOM using the new series UID
+    out_filename = series_uid + "#" + file.split("#", 1)[1]
+    dcm_file_out = Path(out_folder) / out_filename
+
+    # Load the input slice
+    ds = pydicom.dcmread(dcm_file_in)
+    
+    # Check if private tags already exist
+    # Private tags are (7771,0010), (7771,1001), and (7771,1002)
+    tags_exist = (
+        (0x7771, 0x0010) in ds and
+        (0x7771, 0x1001) in ds and
+        (0x7771, 0x1002) in ds
+    )
+    
+    if not tags_exist:
+        # Tags don't exist, so we'll add them and modify the series
+        
+        # Set the new series UID
+        ds.SeriesInstanceUID = series_uid
+        
+        # Set a UID for this slice (every slice needs to have a unique instance UID)
+        ds.SOPInstanceUID = generate_uid()
+        
+        # Add an offset to the series number (to avoid collision in PACS if sending back into the same study)
+        ds.SeriesNumber = ds.SeriesNumber + settings["series_offset"]
+        
+        # Update the series description to indicate this is a modified series
+        ds.SeriesDescription = "MODIFIED(" + ds.SeriesDescription + ")"
+        
+        # ===== STANDARD TAG MODIFICATION =====
+        # Set Institution Name (0008,0080) to "NVRA"
+        ds.InstitutionName = settings["institution_name"]
+        
+        # Set Institutional Department Name (0008,1040) to "NVRA"
+        ds.InstitutionalDepartmentName = settings["department_name"]
+        
+        # ===== PRIVATE TAG CREATION =====
+        # Create private tag (7771,0010) with VR Type LO and value "NL_PRIVATE"
+        # This tag identifies the private creator
+        ds.add_new(0x77710010, 'LO', settings["private_creator"])
+        
+        # Create private tag (7771,1001) with VR Type LO and value "PIPELINE"
+        ds.add_new(0x77711001, 'LO', settings["pipeline_value"])
+        
+        # Create private tag (7771,1002) with VR Type LO and value "MAIN"
+        ds.add_new(0x77711002, 'LO', settings["main_value"])
+    else:
+        # Tags already exist - keep original series UID and instance UID
+        # Just copy the file without modification
+        pass
+    
+    # Write the DICOM file to the output folder
+    ds.save_as(dcm_file_out)
+
+
+def main(args=sys.argv[1:]):
+    """
+    Main entry function of the DICOM tag manipulation module. 
+    The module is called with two arguments from the function docker-entrypoint.sh:
+    'dicom_tag_manipulator [input-folder] [output-folder]'. The exact paths of the 
+    input-folder and output-folder are provided by mercure via environment variables
+    """
+    # Print some output, so that it can be seen in the logfile that the module was executed
+    print("DICOM Private Tag Creator Module - Starting")
+
+    # Check if the input and output folders are provided as arguments
+    if len(sys.argv) < 3:
+        print("Error: Missing arguments!")
+        print("Usage: dicom_tag_manipulator [input-folder] [output-folder]")
+        sys.exit(1)
+
+    # Check if the input and output folders actually exist
+    in_folder = sys.argv[1]
+    out_folder = sys.argv[2]
+    if not Path(in_folder).exists() or not Path(out_folder).exists():
+        print("IN/OUT paths do not exist")
+        sys.exit(1)
+
+    # Load the task.json file, which contains the settings for the processing module
+    try:
+        with open(Path(in_folder) / "task.json", "r") as json_file:
+            task = json.load(json_file)
+    except Exception:
+        print("Error: Task file task.json not found")
+        sys.exit(1)
+
+    # Create default values for all module settings
+    settings = {
+        "institution_name": "NVRA",       # Value for Institution Name tag (0008,0080)
+        "department_name": "NVRA",        # Value for Institutional Department Name tag (0008,1040)
+        "private_creator": "NL_PRIVATE",  # Value for private creator tag (7771,0010)
+        "pipeline_value": "PIPELINE",     # Value for pipeline tag (7771,1001)
+        "main_value": "MAIN",             # Value for main tag (7771,1002)
+        "series_offset": 1000             # Offset to add to series number
+    }
+
+    # Overwrite default values with settings from the task file (if present)
+    if task.get("process", ""):
+        settings.update(task["process"].get("settings", {}))
+
+    # Print the configured tag values for debugging
+    print(f"Institution Name: {settings['institution_name']}")
+    print(f"Institutional Department Name: {settings['department_name']}")
+    print(f"Private Creator: {settings['private_creator']}")
+    print(f"Pipeline Value: {settings['pipeline_value']}")
+    print(f"Main Value: {settings['main_value']}")
+
+    # Collect all DICOM series in the input folder. By convention, DICOM files provided by
+    # mercure have the format [series_UID]#[file_UID].dcm. Thus, by splitting the file
+    # name at the "#" character, the series UID can be obtained
+    series = {}
+    for entry in os.scandir(in_folder):
+        if entry.name.endswith(".dcm") and not entry.is_dir():
+            # Get the Series UID from the file name
+            seriesString = entry.name.split("#", 1)[0]
+            # If this is the first image of the series, create new file list for the series
+            if seriesString not in series.keys():
+                series[seriesString] = []
+            # Add the current file to the file list
+            series[seriesString].append(entry.name)
+
+    # Now loop over all series found
+    for item in series:
+        # Create a new series UID, which will be used for the modified DICOM series (to avoid
+        # collision with the original series)
+        series_uid = generate_uid()
+        # Now loop over all slices of the current series and call the processing function
+        for image_filename in series[item]:
+            process_image(image_filename, in_folder, out_folder, series_uid, settings)
+    
+    print(f"Processed {sum(len(files) for files in series.values())} DICOM files")
+    print("DICOM Private Tag Creator Module - Complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add gcp_service_account_json_path and gcp_auth_scopes fields to DicomWebTarget
- Add auth_method selector field for clarity
- Implement GCP authenticated session using google-auth library
- Add upload_gcp_key endpoint for secure key file uploads
- Update UI templates with authentication method selection
- Add google-auth dependencies to requirements.txt
- Add DICOM tag manipulation processing module (tagmap_new)
- Add test stubs for GCP authentication
- Update .gitignore to exclude GCP service account keys