### PR TITLE
Add notable adoptions documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@
 
 A flexible DICOM routing and processing solution with user-friendly web interface and extensive monitoring functions. Custom processing modules can be implemented as Docker containers. mercure has been written in the Python language and uses the DCMTK toolkit for the underlying DICOM communication. It can be deployed either as containerized single-server installation using Docker Compose, or as scalable cluster installation using Nomad. mercure consists of multiple service modules that handle different steps of the processing pipeline.
 
-Installation instructions and usage information can be found in the project documentation:  
+Installation instructions and usage information can be found in the project documentation:
 https://mercure-imaging.org/docs/index.html
+
+## Notable Adoptions
+
+mercure is used by research groups beyond the original development team. See the [Notable Adoptions](https://mercure-imaging.org/docs/adoptions.html) page in the documentation for details, including integration with the [BIDS-flux](https://bids-flux-docs.readthedocs.io/) multi-site neuroimaging platform.
 
 
 ## Receiver

--- a/docs/adoptions.rst
+++ b/docs/adoptions.rst
@@ -14,12 +14,12 @@ BIDS-flux (Multi-site Neuroimaging)
 **Institutions involved:**
 
 * CHU Sainte-Justine (Montreal)
-* University of Catalonia (Universitat Oberta de Catalunya)
+* Alberta's Children Hospital (Calgary)
 * SickKids - The Hospital for Sick Children (Toronto)
 
 **How mercure is used:**
 
-In the BIDS-flux architecture, mercure serves as the **data ingestion and curation component** at each local research site. It handles incoming DICOM data from MRI scanners before the data flows through the rest of the pipeline:
+In the BIDS-flux architecture, mercure serves as a dicom router at each local research site, enabling custom container to be executed on each new session, and  routing dicoms to proprietary dicom-only processing for synthetic MRI. It handles incoming DICOM data from MRI scanners before the data flows through the rest of the pipeline:
 
 .. code-block:: text
 

--- a/docs/adoptions.rst
+++ b/docs/adoptions.rst
@@ -1,0 +1,33 @@
+Notable Adoptions
+=================
+
+mercure has been adopted by research groups and institutions beyond the original development team at NYU Langone Health / CAI2R. This page documents known deployments and integrations in the community.
+
+If your institution uses mercure and you would like to be listed here, please submit a pull request or open an issue on our `GitHub repository <https://github.com/mercure-imaging/mercure>`_.
+
+
+BIDS-flux (Multi-site Neuroimaging)
+-----------------------------------
+
+`BIDS-flux <https://bids-flux-docs.readthedocs.io/>`_ is a scalable data management platform for multi-site neuroimaging research, built on FAIR principles (Findability, Accessibility, Interoperability, Reusability).
+
+**Institutions involved:**
+
+* CHU Sainte-Justine (Montreal)
+* University of Catalonia (Universitat Oberta de Catalunya)
+* SickKids - The Hospital for Sick Children (Toronto)
+
+**How mercure is used:**
+
+In the BIDS-flux architecture, mercure serves as the **data ingestion and curation component** at each local research site. It handles incoming DICOM data from MRI scanners before the data flows through the rest of the pipeline:
+
+.. code-block:: text
+
+   Mercure (ingestion) → Heudiconv (DICOM-to-BIDS) → Standardization →
+   Anonymization → Quality control (MRIQC) → Processing (BIDSApps)
+
+The platform operates on a distributed model where mercure runs as part of the local infrastructure at individual sites, enabling independent data contribution to a centralized repository. This makes mercure essential for their distributed multi-site data collection model.
+
+**Notable project:** The Canadian Paediatric Imaging Platform (C-PIP), a three-year longitudinal study involving approximately 750 pediatric participants undergoing annual MRI scans and neuropsychological assessments.
+
+**More information:** https://bids-flux-docs.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ mercure is a flexible open-source DICOM orchestration platform. It offers an int
    :titlesonly:
 
    support
+   adoptions
    releases
 
 .. toctree::


### PR DESCRIPTION
Add docs/adoptions.rst documenting external projects using mercure, starting with BIDS-flux (multi-site neuroimaging platform used by CHU Sainte-Justine, University of Catalonia, and SickKids Toronto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@bpinsard , please review on whether me or claude didn't mis-represent anything

Dear mercure folks, please review and potentially expand up to your desires.

My motivation was, inspired by @bpinsard's use, I thought to try but tried to find who else uses it and failed :-/ hence decided to contribute such a section for others 